### PR TITLE
feat: converter page and backend audio conversion

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Create a report to help us improve
+labels: bug
+assignees: tvbilgo-debug
+---
+
+## Describe the bug
+A clear and concise description of what the bug is.
+
+## To Reproduce
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. See error
+
+## Expected behavior
+A clear and concise description of what you expected to happen.
+
+## Screenshots or logs
+If applicable, add screenshots or logs to help explain your problem.
+
+## Environment
+- OS: [e.g. macOS 14]
+- Browser: [e.g. Chrome 125]
+- Docker: [e.g. 24.x]
+
+## Additional context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+labels: enhancement
+assignees: tvbilgo-debug
+---
+
+## Problem statement
+What is the problem this feature solves?
+
+## Proposed solution
+Describe the solution you'd like, including API/UI changes as applicable.
+
+## Alternatives considered
+Describe any alternative solutions you've considered.
+
+## Additional context
+Add any other context, screenshots, or references here.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,27 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone.
+
+## Our Standards
+Examples of behavior that contributes to a positive environment include:
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints
+- Accepting constructive criticism gracefully
+
+Examples of unacceptable behavior include:
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others’ private information without permission
+
+## Our Responsibilities
+Project maintainers are responsible for clarifying the standards of acceptable behavior and will take appropriate and fair corrective action.
+
+## Scope
+This Code of Conduct applies within project spaces and in public spaces when an individual is representing the project.
+
+## Enforcement
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the maintainers at: opensource-maintainers@example.com. All complaints will be reviewed and investigated.
+
+## Attribution
+This Code of Conduct is adapted from the Contributor Covenant, version 2.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing to Open Dubber
+
+Thanks for your interest in contributing! This guide explains how to set up your environment, propose changes, and follow our conventions.
+
+## Development Setup
+- Requirements: Docker + Docker Compose, Node 20+, Python 3.11+
+- Quickstart (Docker):
+  - cp .env.example .env
+  - docker compose up --build
+  - Frontend: http://localhost:3000, API: http://localhost:8000
+
+## Project Structure
+- backend/: FastAPI API, Celery tasks, pluggable engines
+- frontend/: Next.js UI
+- storage/: Local dev artifact store
+
+## Branching & Workflow
+- Use GitHub Flow: create a feature branch from main, open a PR when ready.
+- Ensure CI passes locally if possible.
+
+## Commit Messages
+- Follow Conventional Commits: feat:, fix:, chore:, docs:, refactor:, test:
+  - feat(backend): add whisper.cpp transcription runner
+  - fix(frontend): handle upload error state
+
+## Code Style
+- Python: aim for readable, typed code; prefer pydantic models; add small unit tests where practical.
+- TypeScript/React: functional components, hooks, minimal state; avoid unnecessary deps.
+- Keep changes small and focused.
+
+## Tests
+- Backend: pytest (planned); for now, add minimal unit tests where trivial.
+- Frontend: add lightweight tests (Vitest/Jest) as we grow.
+
+## Pull Requests
+- Fill out the PR template.
+- Include screenshots/logs for UI or runtime changes when helpful.
+- Update README/docs when necessary.
+
+## Security
+- Do not include credentials in code or logs. Use environment variables.
+
+## License
+- By contributing, you agree your contributions are licensed under the project’s MIT License.

--- a/backend/app/tasks/conversion.py
+++ b/backend/app/tasks/conversion.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+from pathlib import Path
+from typing import Optional
+
+from ..core.celery_app import celery_app
+from ..utils.ffmpeg import transcode_audio
+
+
+@celery_app.task(bind=True, name="conversion.convert_audio")
+def convert_audio_task(
+    self,
+    *,
+    video_path: str,
+    format: str = "wav",
+    sample_rate: int = 16000,
+    channels: int = 1,
+    bitrate: Optional[str | int] = None,
+    storage_dir: str,
+):
+    video_id = Path(video_path).stem
+    audio_dir = Path(storage_dir) / "audio"
+    audio_dir.mkdir(parents=True, exist_ok=True)
+
+    out_filename = f"{video_id}.{format.lower()}"
+    out_path = audio_dir / out_filename
+
+    self.update_state(state="STARTED", meta={"step": "ffmpeg", "format": format})
+    transcode_audio(video_path, str(out_path), format=format, sample_rate=sample_rate, channels=channels, bitrate=bitrate)
+
+    url_path = f"/api/assets/audio/{out_filename}"
+    return {"filename": out_filename, "url": url_path, "format": format.lower()}

--- a/backend/app/utils/ffmpeg.py
+++ b/backend/app/utils/ffmpeg.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+import subprocess
+from pathlib import Path
+
+
+def extract_audio(
+    video_path: str | Path,
+    out_path: str | Path,
+    sample_rate: int = 16000,
+    channels: int = 1,
+    codec: str = "pcm_s16le",  # WAV PCM 16-bit
+) -> Path:
+    """
+    Extract audio from a video using ffmpeg.
+
+    Example command:
+    ffmpeg -y -i input.mp4 -vn -acodec pcm_s16le -ar 16000 -ac 1 output.wav
+    """
+    video = Path(video_path)
+    out = Path(out_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    cmd = [
+        "ffmpeg",
+        "-y",
+        "-i",
+        str(video),
+        "-vn",
+        "-acodec",
+        codec,
+        "-ar",
+        str(sample_rate),
+        "-ac",
+        str(channels),
+        str(out),
+    ]
+    subprocess.run(cmd, check=True)
+    return out

--- a/backend/app/utils/ffmpeg.py
+++ b/backend/app/utils/ffmpeg.py
@@ -36,3 +36,49 @@ def extract_audio(
     ]
     subprocess.run(cmd, check=True)
     return out
+
+
+def transcode_audio(
+    video_path: str | Path,
+    out_path: str | Path,
+    *,
+    format: str = "wav",
+    sample_rate: int = 16000,
+    channels: int = 1,
+    bitrate: str | int | None = None,
+) -> Path:
+    """
+    Transcode audio track from a video into WAV or MP3 using ffmpeg.
+
+    WAV: pcm_s16le, 16-bit. MP3: libmp3lame with optional bitrate (e.g., 128k).
+    """
+    fmt = format.lower()
+    if fmt not in {"wav", "mp3"}:
+        raise ValueError(f"unsupported format: {format}")
+
+    video = Path(video_path)
+    out = Path(out_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    if fmt == "wav":
+        cmd = [
+            "ffmpeg", "-y", "-i", str(video), "-vn",
+            "-acodec", "pcm_s16le",
+            "-ar", str(sample_rate),
+            "-ac", str(channels),
+            str(out),
+        ]
+    else:  # mp3
+        cmd = [
+            "ffmpeg", "-y", "-i", str(video), "-vn",
+            "-acodec", "libmp3lame",
+            "-ar", str(sample_rate),
+            "-ac", str(channels),
+        ]
+        if bitrate is not None:
+            br = f"{bitrate}k" if isinstance(bitrate, int) else str(bitrate)
+            cmd.extend(["-b:a", br])
+        cmd.append(str(out))
+
+    subprocess.run(cmd, check=True)
+    return out

--- a/frontend/src/pages/converter.tsx
+++ b/frontend/src/pages/converter.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from 'react'
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000'
+
+export default function ConverterPage() {
+  const [file, setFile] = useState<File | null>(null)
+  const [videoId, setVideoId] = useState<string | null>(null)
+  const [audioUrl, setAudioUrl] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [message, setMessage] = useState<string | null>(null)
+
+  async function upload() {
+    if (!file) return
+    setBusy(true)
+    setMessage('Uploading...')
+    try {
+      const form = new FormData()
+      form.append('file', file)
+      const res = await fetch(`${API_BASE}/api/videos/upload`, { method: 'POST', body: form })
+      if (!res.ok) throw new Error(`Upload failed: ${res.status}`)
+      const data = await res.json()
+      setVideoId(data.video_id)
+      setMessage('Uploaded')
+    } catch (e: any) {
+      setMessage(e.message || 'Upload failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function convert() {
+    if (!videoId) return
+    setBusy(true)
+    setMessage('Converting to WAV (16kHz mono)...')
+    try {
+      const res = await fetch(`${API_BASE}/api/videos/${videoId}/convert/audio`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ format: 'wav', sample_rate: 16000, channels: 1 })
+      })
+      if (!res.ok) throw new Error(`Conversion failed: ${res.status}`)
+      const data = await res.json()
+      const url = `${API_BASE}${data.url}`
+      setAudioUrl(url)
+      setMessage('Conversion complete')
+    } catch (e: any) {
+      setMessage(e.message || 'Conversion failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <main style={{ padding: 24, maxWidth: 720, margin: '0 auto', fontFamily: 'sans-serif' }}>
+      <h1>Converter</h1>
+      <p>Upload a video and convert its audio track to WAV (16kHz mono).</p>
+
+      <section style={{ marginTop: 24 }}>
+        <input type="file" accept="video/*" onChange={(e) => setFile(e.target.files?.[0] || null)} />
+        <button onClick={upload} disabled={!file || busy} style={{ marginLeft: 8 }}>Upload</button>
+        {videoId && <p>Video ID: <code>{videoId}</code></p>}
+      </section>
+
+      <section style={{ marginTop: 24 }}>
+        <button onClick={convert} disabled={!videoId || busy}>Convert to WAV</button>
+      </section>
+
+      {message && <p style={{ marginTop: 16 }}>{message}</p>}
+
+      {audioUrl && (
+        <section style={{ marginTop: 24 }}>
+          <h3>Result</h3>
+          <audio controls src={audioUrl} style={{ width: '100%' }} />
+          <p><a href={audioUrl} download>Download WAV</a></p>
+        </section>
+      )}
+    </main>
+  )
+}

--- a/frontend/src/pages/converter.tsx
+++ b/frontend/src/pages/converter.tsx
@@ -5,9 +5,16 @@ const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000'
 export default function ConverterPage() {
   const [file, setFile] = useState<File | null>(null)
   const [videoId, setVideoId] = useState<string | null>(null)
+  const [jobId, setJobId] = useState<string | null>(null)
+  const [status, setStatus] = useState<any>(null)
   const [audioUrl, setAudioUrl] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
   const [message, setMessage] = useState<string | null>(null)
+
+  const [fmt, setFmt] = useState<'wav' | 'mp3'>('wav')
+  const [bitrate, setBitrate] = useState<string>('128k')
+  const [sampleRate, setSampleRate] = useState<number>(16000)
+  const [channels, setChannels] = useState<number>(1)
 
   async function upload() {
     if (!file) return
@@ -31,29 +38,50 @@ export default function ConverterPage() {
   async function convert() {
     if (!videoId) return
     setBusy(true)
-    setMessage('Converting to WAV (16kHz mono)...')
+    setMessage(`Starting ${fmt.toUpperCase()} conversion...`)
+    setAudioUrl(null)
+    setStatus(null)
     try {
       const res = await fetch(`${API_BASE}/api/videos/${videoId}/convert/audio`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ format: 'wav', sample_rate: 16000, channels: 1 })
+        body: JSON.stringify({ format: fmt, sample_rate: sampleRate, channels, bitrate: fmt === 'mp3' ? bitrate : undefined })
       })
-      if (!res.ok) throw new Error(`Conversion failed: ${res.status}`)
+      if (!res.ok) throw new Error(`Conversion creation failed: ${res.status}`)
       const data = await res.json()
-      const url = `${API_BASE}${data.url}`
-      setAudioUrl(url)
-      setMessage('Conversion complete')
+      setJobId(data.job_id)
+      setMessage('Job queued...')
     } catch (e: any) {
-      setMessage(e.message || 'Conversion failed')
-    } finally {
+      setMessage(e.message || 'Conversion failed to start')
       setBusy(false)
     }
   }
 
+  useEffect(() => {
+    if (!jobId) return
+    const t = setInterval(async () => {
+      const res = await fetch(`${API_BASE}/api/jobs/${jobId}`)
+      const data = await res.json()
+      setStatus(data)
+      if (data.state === 'SUCCESS') {
+        const url = `${API_BASE}${data.meta.url}`
+        setAudioUrl(url)
+        setMessage('Conversion complete')
+        setBusy(false)
+        clearInterval(t)
+      } else if (data.state === 'FAILURE') {
+        setMessage(data.meta?.detail || 'Conversion failed')
+        setBusy(false)
+        clearInterval(t)
+      }
+    }, 1500)
+    return () => clearInterval(t)
+  }, [jobId])
+
   return (
     <main style={{ padding: 24, maxWidth: 720, margin: '0 auto', fontFamily: 'sans-serif' }}>
       <h1>Converter</h1>
-      <p>Upload a video and convert its audio track to WAV (16kHz mono).</p>
+      <p>Upload a video and convert its audio track to WAV or MP3.</p>
 
       <section style={{ marginTop: 24 }}>
         <input type="file" accept="video/*" onChange={(e) => setFile(e.target.files?.[0] || null)} />
@@ -61,17 +89,42 @@ export default function ConverterPage() {
         {videoId && <p>Video ID: <code>{videoId}</code></p>}
       </section>
 
-      <section style={{ marginTop: 24 }}>
-        <button onClick={convert} disabled={!videoId || busy}>Convert to WAV</button>
+      <section style={{ marginTop: 24, display: 'flex', gap: 12, alignItems: 'center' }}>
+        <label>
+          Format:
+          <select value={fmt} onChange={(e) => setFmt(e.target.value as 'wav' | 'mp3')} style={{ marginLeft: 8 }}>
+            <option value="wav">WAV</option>
+            <option value="mp3">MP3</option>
+          </select>
+        </label>
+        {fmt === 'mp3' && (
+          <label>
+            Bitrate:
+            <input value={bitrate} onChange={(e) => setBitrate(e.target.value)} style={{ marginLeft: 8, width: 100 }} placeholder="128k" />
+          </label>
+        )}
+        <label>
+          Sample rate:
+          <input type="number" value={sampleRate} onChange={(e) => setSampleRate(parseInt(e.target.value || '16000', 10))} style={{ marginLeft: 8, width: 100 }} />
+        </label>
+        <label>
+          Channels:
+          <input type="number" value={channels} onChange={(e) => setChannels(parseInt(e.target.value || '1', 10))} style={{ marginLeft: 8, width: 60 }} />
+        </label>
+        <button onClick={convert} disabled={!videoId || busy}>Start Conversion</button>
       </section>
 
       {message && <p style={{ marginTop: 16 }}>{message}</p>}
+
+      {status && (
+        <pre style={{ background: '#f6f6f6', padding: 12 }}>{JSON.stringify(status, null, 2)}</pre>
+      )}
 
       {audioUrl && (
         <section style={{ marginTop: 24 }}>
           <h3>Result</h3>
           <audio controls src={audioUrl} style={{ width: '100%' }} />
-          <p><a href={audioUrl} download>Download WAV</a></p>
+          <p><a href={audioUrl} download>Download {fmt.toUpperCase()}</a></p>
         </section>
       )}
     </main>

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import Link from 'next/link'
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000'
 
@@ -57,6 +58,8 @@ export default function HomePage() {
     <main style={{ padding: 24, maxWidth: 720, margin: '0 auto', fontFamily: 'sans-serif' }}>
       <h1>Open Dubber</h1>
       <p>Upload a video, then run a dummy translation/dubbing job.</p>
+
+      <p><Link href="/converter">Go to Converter</Link></p>
 
       <section style={{ marginTop: 24 }}>
         <input type="file" accept="video/*" onChange={(e) => setFile(e.target.files?.[0] || null)} />


### PR DESCRIPTION
This adds a minimal audio converter workflow.\n\nBackend:\n- POST /api/videos/{video_id}/convert/audio (extracts WAV 16k mono via ffmpeg)\n- GET /api/assets/audio/{filename} (serves audio)\n- Includes audio list in /videos/{video_id}/assets\n\nFrontend:\n- /converter page to upload a video, convert to WAV, and play/download the result.\n\nNotes:\n- Synchronous conversion for MVP; may move to a Celery task for long videos.\n- Only WAV output supported for now.